### PR TITLE
hotfix: incorrect ward's allowed discharge days in ward creation

### DIFF
--- a/hospitool/cms/forms/ward_form.py
+++ b/hospitool/cms/forms/ward_form.py
@@ -16,7 +16,7 @@ class WeekdaySelectField(forms.MultipleChoiceField):
     def prepare_value(self, value):
         """ Convert binary-encoded int backing field to selection of weekdays. """
         if isinstance(value, int):
-            return [day for day, name in enumerate(days_of_week.WEEKDAYS_LONG)]
+            return [day for day, name in enumerate(days_of_week.WEEKDAYS_LONG) if value & day]
         return value
     
     def to_python(self, value):

--- a/hospitool/cms/views/floor/add_ward.py
+++ b/hospitool/cms/views/floor/add_ward.py
@@ -4,6 +4,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
+from ...constants import days_of_week
 from ...decorators import permission_required
 from ...forms import WardForm
 from ...models import Floor
@@ -34,6 +35,9 @@ class WardCreateView(TemplateView):
         """
         data = {k: v for k, v in request.POST.items()}
         data["floor"] = Floor.objects.get(pk=request.POST["floor_id"])
+        # manually set discharge days default to all days (otherwise overwritten when cleaning for whatever reason)
+        data["allowed_discharge_days"] = [0b1 << day for day in range(len(days_of_week.WEEKDAYS_SHORT))]
+        
         ward_form = WardForm(
             data=data, additional_instance_attributes={"creator": request.user}
         )


### PR DESCRIPTION
Hotfix for incorrect configuration of ward's initial allowed discharge days when creating a ward with the recently reworked ward creation (floor view).
Was being reset to 0 = no weekday (even though default should be 127 = all weekdays).

(Also fixes previously missed conversion from int backing field to list of binary-encoded allowed discharge days - this should never actually be called, but it's there just to be sure :) )